### PR TITLE
Tool Enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(AnnotationParser)
-
+ 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
+ 
 find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
-
+ 
 add_executable(parser
     main.cpp
     ASTVisitor.cpp
@@ -21,19 +21,47 @@ add_executable(parser
     SyntaxChecker.cpp
     ManifestMerger.cpp
 )
-
+ 
 target_include_directories(parser
     PRIVATE 
     ${LLVM_INCLUDE_DIRS}
     ${CLANG_INCLUDE_DIRS}
 )
-
+ 
+# --- Platform-dependent linking ---
+if (WIN32)
+    set(CLANG_LIBS
+        clangTooling
+        clangFrontend
+        clangDriver
+        clangParse
+        clangSerialization
+        clangSema
+        clangEdit
+        clangAnalysis
+        clangAST
+        clangLex
+        clangBasic
+    )
+    llvm_map_components_to_libnames(LLVM_LIBS
+        support
+        core
+        option
+        binaryformat
+        demangle
+        # add more if you get linker errors
+    )
+else()
+    set(CLANG_LIBS clang-cpp)
+    set(LLVM_LIBS LLVM)
+endif()
+ 
 target_link_libraries(parser
     PRIVATE
-    clang-cpp
-    LLVM
+    ${CLANG_LIBS}
+    ${LLVM_LIBS}
 )
-
+ 
 target_compile_definitions(parser
     PRIVATE
     ${LLVM_DEFINITIONS}

--- a/Component.cpp
+++ b/Component.cpp
@@ -14,6 +14,10 @@ void Component::addReference(const Reference& ref) {
     references.push_back(ref);
 }
 
+void Component::setAttributes(const nlohmann::json& attrs) {
+    attributes = attrs;
+}
+
 std::string Component::getClassName() const {
     return className;
 }
@@ -28,4 +32,13 @@ nlohmann::json Component::getProperties() const {
 
 std::vector<Reference> Component::getReferences() const {
     return references;
+}
+
+// NEW: Get component attributes
+nlohmann::json Component::getAttributes() const {
+    return attributes;
+}
+
+bool Component::hasAttributes() const {
+    return !attributes.empty();
 }

--- a/Component.h
+++ b/Component.h
@@ -12,8 +12,11 @@ public:
     Component(const std::string& className);
     void addInterface(const std::string& interface);
     void setProperties(const nlohmann::json& props);
+    void setAttributes(const nlohmann::json& attrs);
     void addReference(const Reference& ref);
 
+    bool hasAttributes() const;
+    nlohmann::json getAttributes() const;
     std::string getClassName() const;
     std::vector<std::string> getInterfaces() const;
     nlohmann::json getProperties() const;
@@ -22,6 +25,7 @@ public:
 private:
     std::string className;
     std::vector<std::string> interfaces;
+    nlohmann::json attributes;
     nlohmann::json properties;
     std::vector<Reference> references;
 };

--- a/ComponentParser.cpp
+++ b/ComponentParser.cpp
@@ -82,6 +82,9 @@ void ComponentParser::parseReferences(Component& component, const clang::CXXReco
                     std::string ParamTypeName = ParamType.getAsString();
                     std::string ParamName = Param->getNameAsString();
                     std::vector<std::string> RefNameAndInterface = DeriveNameFromType(ParamTypeName);
+                    
+                    // Use the clean interface name (RefNameAndInterface[1]) as the reference name
+                    // and the full interface type (RefNameAndInterface[0]) as the interface
                     Reference ref = referenceParser.parse(ConstructorCommentText.str(), RefNameAndInterface[1], RefNameAndInterface[0]);
                     component.addReference(ref);
                 }

--- a/ComponentParser.cpp
+++ b/ComponentParser.cpp
@@ -7,34 +7,29 @@
 
 using namespace clang;
 
-Component ComponentParser::parse(const clang::CXXRecordDecl* Declaration, clang::ASTContext* Context) {
-    std::string ClassName = Declaration->getQualifiedNameAsString();
-    Component component(ClassName);
-
-    const clang::RawComment *RC = Context->getRawCommentForDeclNoCache(Declaration);
+Component ComponentParser::parse(const clang::CXXRecordDecl* record, clang::ASTContext* Context) {
+    Component component(record->getQualifiedNameAsString());
+    
+    // Extract interfaces (existing logic)
+    for (const auto& base : record->bases()) {
+        if (const auto* baseDecl = base.getType()->getAsCXXRecordDecl()) {
+            component.addInterface(baseDecl->getQualifiedNameAsString());
+        }
+    }
+    
+    // Parse comments for annotations
+    const clang::RawComment* RC = Context->getRawCommentForDeclNoCache(record);
     if (RC) {
-        clang::StringRef CommentText = RC->getRawText(Context->getSourceManager());
-        std::string commentStr = CommentText.str();
-
-        if (!SyntaxChecker::checkBalancedBraces(commentStr, errorCollector, RC->getBeginLoc())) {
-            // Handle the error, perhaps by returning early or setting a flag
-            errorCollector.addError("No comment found for component " + ClassName, 
-                        Declaration->getLocation(), 
-                        ErrorSeverity::WARNING, 
-                        ErrorCategory::COMPONENT);
-        }
+        // Parse component-level attributes (@component {key=value})
+        parseComponentAttributes(component, RC, Context);
+        
+        // Parse properties (@properties, @property)
         parseProperties(component, RC, Context);
+        
+        // Parse references (existing logic)
+        parseReferences(component, record, Context);
     }
-
-    for (const auto &Base : Declaration->bases()) {
-        clang::QualType BaseType = Base.getType();
-        if (const auto *RecordDecl = BaseType->getAsCXXRecordDecl()) {
-            component.addInterface(RecordDecl->getQualifiedNameAsString());
-        }
-    }
-
-    parseReferences(component, Declaration, Context);
-
+    
     return component;
 }
 
@@ -95,8 +90,9 @@ void ComponentParser::parseReferences(Component& component, const clang::CXXReco
 
 void ComponentParser::parseProperties(Component& component, const clang::RawComment* RC, clang::ASTContext* Context) {
     clang::StringRef CommentText = RC->getRawText(Context->getSourceManager());
+    
+    // Handle @properties (goes into properties section)
     size_t propertiesStart = CommentText.find("@properties");
-    size_t propertyStart = CommentText.find("@property");
     if (propertiesStart != clang::StringRef::npos) {
         size_t jsonStart = CommentText.find('{', propertiesStart);
         size_t jsonEnd = CommentText.rfind('}');
@@ -107,7 +103,9 @@ void ComponentParser::parseProperties(Component& component, const clang::RawComm
                 component.setProperties(properties);
             }
         }
-    } else if (propertyStart != clang::StringRef::npos) {
+    }
+    // Handle @property (external file - goes into properties section)
+    else if (size_t propertyStart = CommentText.find("@property"); propertyStart != clang::StringRef::npos) {
         size_t pathStart = CommentText.find('{', propertyStart);
         size_t pathEnd = CommentText.find('}', pathStart);
         if (pathStart != clang::StringRef::npos && pathEnd != clang::StringRef::npos) {
@@ -131,5 +129,25 @@ void ComponentParser::parseExternalProperties(Component& component, const std::s
     } else {
         // Use ErrorCollector to report file not found error
         llvm::errs() << "Error opening file: " << filePath << "\n";
+    }
+}
+
+// NEW: Parse component attributes (separate method)
+void ComponentParser::parseComponentAttributes(Component& component, const clang::RawComment* RC, clang::ASTContext* Context) {
+    clang::StringRef CommentText = RC->getRawText(Context->getSourceManager());
+    
+    // Handle @component {key=value, key=value} - component-level attributes
+    size_t componentStart = CommentText.find("@component");
+    if (componentStart != clang::StringRef::npos) {
+        size_t attrStart = CommentText.find('{', componentStart);
+        size_t attrEnd = CommentText.find('}', attrStart);
+        if (attrStart != clang::StringRef::npos && attrEnd != clang::StringRef::npos) {
+            std::string attributesString = CommentText.substr(attrStart + 1, attrEnd - attrStart - 1).str();
+            // Use PropertyParser to parse key=value pairs with dot notation support
+            nlohmann::json attributes = propertyParser.parse(attributesString);
+            if (!attributes.empty()) {
+                component.setAttributes(attributes);
+            }
+        }
     }
 }

--- a/ComponentParser.h
+++ b/ComponentParser.h
@@ -21,6 +21,7 @@ private:
     void parseReferences(Component& component, const clang::CXXRecordDecl* Declaration, clang::ASTContext* Context);
     void parseProperties(Component& component, const clang::RawComment* RC, clang::ASTContext* Context);
     void parseExternalProperties(Component& component, const std::string& filePath, clang::ASTContext* Context);
+    void parseComponentAttributes(Component& component, const clang::RawComment* RC, clang::ASTContext* Context);  // NEW
     ReferenceParser referenceParser;
     PropertyParser propertyParser;
     ErrorCollector& errorCollector;

--- a/JsonGenerator.cpp
+++ b/JsonGenerator.cpp
@@ -2,10 +2,10 @@
 #include <fstream>
 
 nlohmann::json JsonGenerator::generateJson(const std::vector<Component>& components) {
-    nlohmann::json manifest;
+
     // manifest["bundle.symbolic_name"] = "DSGraph05";
     // manifest["bundle.name"] = "DSGraph05";
-    
+    nlohmann::json manifest;
     nlohmann::json scr;
     scr["version"] = 1;
     scr["components"] = nlohmann::json::array();
@@ -14,16 +14,52 @@ nlohmann::json JsonGenerator::generateJson(const std::vector<Component>& compone
         nlohmann::json componentJson;
         componentJson["implementation-class"] = component.getClassName();
         
-        if (!component.getInterfaces().empty()) {
+        // Handle component-level attributes
+        if (component.hasAttributes()) {
+            nlohmann::json attrs = component.getAttributes();
+            
+            // Extract service attributes and create service object
+            if (attrs.contains("service") && attrs["service"].is_object()) {
+                nlohmann::json service;
+                
+                // Add interfaces to service if they exist
+                if (!component.getInterfaces().empty()) {
+                    service["interfaces"] = component.getInterfaces();
+                }
+                
+                // Add service attributes
+                for (auto& [key, value] : attrs["service"].items()) {
+                    service[key] = value;
+                }
+                
+                componentJson["service"] = service;
+                attrs.erase("service"); // Remove from component-level attributes
+            }
+            // If no service attributes but we have interfaces, create service object
+            else if (!component.getInterfaces().empty()) {
+                nlohmann::json service;
+                service["interfaces"] = component.getInterfaces();
+                componentJson["service"] = service;
+            }
+            
+            // Add remaining component-level attributes
+            for (auto& [key, value] : attrs.items()) {
+                componentJson[key] = value;
+            }
+        }
+        // If no attributes but we have interfaces, still create service object
+        else if (!component.getInterfaces().empty()) {
             nlohmann::json service;
             service["interfaces"] = component.getInterfaces();
             componentJson["service"] = service;
         }
 
+        // Handle properties section (separate from component attributes)
         if (!component.getProperties().empty()) {
             componentJson["properties"] = component.getProperties();
         }
 
+        // Handle references (unchanged)
         if (!component.getReferences().empty()) {
             nlohmann::json references = nlohmann::json::array();
             for (const auto& ref : component.getReferences()) {

--- a/PropertyParser.cpp
+++ b/PropertyParser.cpp
@@ -2,6 +2,46 @@
 #include <regex>
 #include <sstream>
 
+nlohmann::json PropertyParser::parseValue(const std::string& value) {
+    std::string trimmedValue = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
+    
+    if (!trimmedValue.empty() && trimmedValue.front() == '[' && trimmedValue.back() == ']') {
+        // Array handling
+        std::string arrayContent = trimmedValue.substr(1, trimmedValue.length() - 2);
+        std::vector<std::string> arrayValues;
+        std::istringstream arrayStream(arrayContent);
+        std::string arrayItem;
+        while (std::getline(arrayStream, arrayItem, ',')) {
+            arrayItem = std::regex_replace(arrayItem, std::regex("^\\s+|\\s+$"), "");
+            arrayValues.push_back(arrayItem);
+        }
+        return arrayValues;
+    } else if (trimmedValue == "true") {
+        return true;
+    } else if (trimmedValue == "false") {
+        return false;
+    } else {
+        return trimmedValue;
+    }
+}
+
+void PropertyParser::setNestedProperty(nlohmann::json& json, const std::string& key, const nlohmann::json& value) {
+    size_t dotPos = key.find('.');
+    if (dotPos != std::string::npos) {
+        std::string parentKey = key.substr(0, dotPos);
+        std::string childKey = key.substr(dotPos + 1);
+        
+        // Create nested object if it doesn't exist
+        if (!json.contains(parentKey)) {
+            json[parentKey] = nlohmann::json::object();
+        }
+        
+        json[parentKey][childKey] = value;
+    } else {
+        json[key] = value;
+    }
+}
+
 nlohmann::json PropertyParser::parse(const std::string& propertiesText) {
     nlohmann::json propertiesJson;
     if(propertiesText.empty()) return propertiesJson;
@@ -10,6 +50,7 @@ nlohmann::json PropertyParser::parse(const std::string& propertiesText) {
     std::string temp;
     bool inArray = false;
 
+    // Split properties by comma (respecting arrays)
     for (char c : propertiesText) {
         if (c == '[') inArray = true;
         if (c == ']') inArray = false;
@@ -23,6 +64,8 @@ nlohmann::json PropertyParser::parse(const std::string& propertiesText) {
     if (!temp.empty()) {
         properties.push_back(temp);
     }
+    
+    // Process each property
     for (const auto& property : properties) {
         size_t delimiterPos = property.find('=');
         if (delimiterPos != std::string::npos) {
@@ -30,27 +73,12 @@ nlohmann::json PropertyParser::parse(const std::string& propertiesText) {
             std::string value = property.substr(delimiterPos + 1);
 
             key = std::regex_replace(key, std::regex("^\\s+|\\s+$"), "");
-            value = std::regex_replace(value, std::regex("^\\s+|\\s+$"), "");
-
-            if (!value.empty() && value.front() == '[' && value.back() == ']') {
-                value = value.substr(1, value.length() - 2);
-                std::vector<std::string> arrayValues;
-                std::istringstream arrayStream(value);
-                std::string arrayItem;
-                while (std::getline(arrayStream, arrayItem, ',')) {
-                    arrayItem = std::regex_replace(arrayItem, std::regex("^\\s+|\\s+$"), "");
-                    arrayValues.push_back(arrayItem);
-                }
-                propertiesJson[key] = arrayValues;
-            } else {
-                if (value == "true") {
-                    propertiesJson[key] = true;
-                } else if (value == "false") {
-                    propertiesJson[key] = false;
-                } else {
-                    propertiesJson[key] = value;
-                }
-            }
+            
+            // Parse value with type identification
+            nlohmann::json parsedValue = parseValue(value);
+            
+            // Set property (handles dot notation)
+            setNestedProperty(propertiesJson, key, parsedValue);
         }
     }
     return propertiesJson;

--- a/PropertyParser.cpp
+++ b/PropertyParser.cpp
@@ -1,5 +1,6 @@
 #include "PropertyParser.h"
 #include <regex>
+#include <sstream>
 
 nlohmann::json PropertyParser::parse(const std::string& propertiesText) {
     nlohmann::json propertiesJson;

--- a/PropertyParser.h
+++ b/PropertyParser.h
@@ -7,4 +7,7 @@ using json = nlohmann::json;
 class PropertyParser {
 public:
     nlohmann::json parse(const std::string& propertyString);
+private:
+    nlohmann::json parseValue(const std::string& value);
+    void setNestedProperty(nlohmann::json& json, const std::string& key, const nlohmann::json& value);
 };

--- a/ReferenceParser.cpp
+++ b/ReferenceParser.cpp
@@ -4,11 +4,23 @@
 Reference ReferenceParser::parse(const std::string& referenceString, const std::string& paramName, const std::string& paramType) {
     Reference reference(paramName, paramType);
     
-    std::regex propRegex("@reference\\s+" + paramName + "\\s*\\{([^}]*)\\}");
+    // Try to match @reference <InterfaceType> {...} using the simplified interface name
+    std::string escapedParamName = std::regex_replace(paramName, std::regex("::"), "\\\\::\\\\");
+    std::regex interfaceRegex("@reference\\s+" + escapedParamName + "\\s*\\{([^}]*)\\}");
     std::smatch match;
-    if (std::regex_search(referenceString, match, propRegex) && match.size() > 1) {
+    
+    if (std::regex_search(referenceString, match, interfaceRegex) && match.size() > 1) {
         std::string propString = match[1].str();
         reference.setProperties(propertyParser.parse(propString));
+    }
+    // Also try with the full paramType in case someone uses the full qualified name
+    else {
+        std::string escapedParamType = std::regex_replace(paramType, std::regex("::"), "\\\\::\\\\");
+        std::regex fullTypeRegex("@reference\\s+" + escapedParamType + "\\s*\\{([^}]*)\\}");
+        if (std::regex_search(referenceString, match, fullTypeRegex) && match.size() > 1) {
+            std::string propString = match[1].str();
+            reference.setProperties(propertyParser.parse(propString));
+        }
     }
     
     return reference;

--- a/ReferenceParser.h
+++ b/ReferenceParser.h
@@ -5,6 +5,9 @@
 
 class ReferenceParser {
 public:
+    // Parses @reference annotations. Now supports both:
+    // @reference InterfaceName {properties...} (preferred)
+    // @reference fully::qualified::InterfaceName {properties...}
     Reference parse(const std::string& referenceString, const std::string& paramName, const std::string& paramType);
 private:
     PropertyParser propertyParser;


### PR DESCRIPTION
- Add separate storage and parsing for component-level attributes
- Component attributes `(@component {key=value})` now go to component level
- Properties `(@properties, @property)` remain in properties section  
- Support dot notation for nested attributes `(service.scope)`
- Maintain backward compatibility with existing annotations
- Improve modularity by leveraging existing `PropertyParser` for all key-value parsing
- Fix reference matching with interface name instead parameter names e,g,
` @reference JsonSerializerImpl {policy-option = greedy, cardinality = 1..n} `
- Here `JsonSerializerImpl` is the reference interface name
- Added CMake build support for windows