### PR TITLE
Add CI workflow for building and testing on Nix systems

### DIFF
--- a/.github/workflows/build_and_test_nix.yml
+++ b/.github/workflows/build_and_test_nix.yml
@@ -1,0 +1,195 @@
+name: BuildAndTestNix
+
+on:
+  push:
+    branches: [ main, develop, feature/* ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  BUILD_DIR: ${{github.workspace}}/build
+
+jobs:
+  linux_minimum_supported_gcc_build:
+    name: Build and Test [ubuntu-22.04, Minimum GCC]
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    
+    - name: Install Dependencies
+      run: |
+        sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+        sudo apt-get update
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+          gcc-11 g++-11 valgrind \
+          llvm-14 llvm-14-dev libclang-14-dev clang-14 \
+          libgtest-dev cmake
+      
+    - name: Configure CMake
+      run: |
+        cmake -B ${{ env.BUILD_DIR }} \
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+          -DCMAKE_C_COMPILER=gcc-11 \
+          -DCMAKE_CXX_COMPILER=g++-11 \
+          -DLLVM_DIR=/usr/lib/llvm-14/lib/cmake/llvm \
+          -DClang_DIR=/usr/lib/llvm-14/lib/cmake/clang
+
+    - name: Build
+      run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }}
+
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest --build-config ${{ env.BUILD_TYPE }} --verbose
+
+  linux_clang_build:
+    name: Build and Test [ubuntu-22.04, Supported Clang]
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+          valgrind lld \
+          llvm-14 llvm-14-dev libclang-14-dev clang-14 \
+          libgtest-dev cmake
+      
+    - name: Configure CMake
+      run: |
+        cmake -B ${{ env.BUILD_DIR }} \
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+          -DCMAKE_C_COMPILER=clang-14 \
+          -DCMAKE_CXX_COMPILER=clang++-14 \
+          -DLLVM_DIR=/usr/lib/llvm-14/lib/cmake/llvm \
+          -DClang_DIR=/usr/lib/llvm-14/lib/cmake/clang
+
+    - name: Build
+      run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }}
+
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest --build-config ${{ env.BUILD_TYPE }} --verbose
+  
+  build_nix:
+    name: Build and Test [${{matrix.os}}]
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-13, macos-14]
+        include:
+          - os: ubuntu-22.04
+            llvm_version: "14"
+            install_deps: |
+              sudo apt-get update
+              sudo apt-get install -y valgrind \
+                llvm-14 llvm-14-dev libclang-14-dev clang-14 \
+                libgtest-dev cmake
+            cmake_extra_args: |
+              -DLLVM_DIR=/usr/lib/llvm-14/lib/cmake/llvm \
+              -DClang_DIR=/usr/lib/llvm-14/lib/cmake/clang
+          - os: macos-13
+            llvm_version: "14"
+            install_deps: |
+              brew install llvm@14 googletest cmake
+            cmake_extra_args: |
+              -DLLVM_DIR=$(brew --prefix llvm@14)/lib/cmake/llvm \
+              -DClang_DIR=$(brew --prefix llvm@14)/lib/cmake/clang
+          - os: macos-14
+            llvm_version: "14"
+            install_deps: |
+              brew install llvm@14 googletest cmake
+            cmake_extra_args: |
+              -DLLVM_DIR=$(brew --prefix llvm@14)/lib/cmake/llvm \
+              -DClang_DIR=$(brew --prefix llvm@14)/lib/cmake/clang
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+         submodules: true
+
+    - name: Install Dependencies
+      run: ${{ matrix.install_deps }}
+
+    - name: Configure CMake
+      run: |
+        cmake -B ${{ env.BUILD_DIR }} \
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+          ${{ matrix.cmake_extra_args }}
+
+    - name: Build
+      run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }}
+
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest --build-config ${{ env.BUILD_TYPE }} --verbose
+
+  build_nix_sanitizers:
+    name: Build and Test with Sanitizers [${{matrix.os}}, ${{matrix.sanitizer}}]
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04]
+        sanitizer: [asan, ubsan, msan]
+        exclude:
+          # MSan requires special libc++ build, skip for now
+          - sanitizer: msan
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          llvm-14 llvm-14-dev libclang-14-dev clang-14 \
+          libgtest-dev cmake
+
+    - name: Configure CMake with ${{ matrix.sanitizer }}
+      run: |
+        SANITIZER_FLAGS=""
+        case "${{ matrix.sanitizer }}" in
+          asan)
+            SANITIZER_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+            ;;
+          ubsan)
+            SANITIZER_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer"
+            ;;
+          msan)
+            SANITIZER_FLAGS="-fsanitize=memory -fno-omit-frame-pointer"
+            ;;
+        esac
+        
+        cmake -B ${{ env.BUILD_DIR }} \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_COMPILER=clang-14 \
+          -DCMAKE_CXX_COMPILER=clang++-14 \
+          -DCMAKE_C_FLAGS="$SANITIZER_FLAGS" \
+          -DCMAKE_CXX_FLAGS="$SANITIZER_FLAGS" \
+          -DCMAKE_EXE_LINKER_FLAGS="$SANITIZER_FLAGS" \
+          -DLLVM_DIR=/usr/lib/llvm-14/lib/cmake/llvm \
+          -DClang_DIR=/usr/lib/llvm-14/lib/cmake/clang
+
+    - name: Build
+      run: cmake --build ${{ env.BUILD_DIR }} --config Debug
+
+    - name: Test with ${{ matrix.sanitizer }}
+      working-directory: ${{ env.BUILD_DIR }}
+      env:
+        ASAN_OPTIONS: "detect_leaks=1:abort_on_error=1"
+        UBSAN_OPTIONS: "print_stacktrace=1:abort_on_error=1"
+        MSAN_OPTIONS: "abort_on_error=1"
+      run: ctest --build-config Debug --verbose


### PR DESCRIPTION
This workflow file sets up CI for building and testing on multiple platforms (Ubuntu and macOS) with different compilers and sanitizers. It includes steps for dependency installation, CMake configuration, building, and testing.